### PR TITLE
fix snapshot report width size

### DIFF
--- a/MVVMArchitectureTemplateSnapshotTests/Reports/Sample一覧画面.md
+++ b/MVVMArchitectureTemplateSnapshotTests/Reports/Sample一覧画面.md
@@ -4,23 +4,23 @@
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_中件数_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_中件数_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_中件数_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_中件数_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 |多件数ダークモード|多件数ライトモード|
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_多件数_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_多件数_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_多件数_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_多件数_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 |少件数ダークモード|少件数ライトモード|
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_少件数_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_少件数_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_少件数_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_少件数_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 |読み込み中ダークモード|読み込み中ライトモード|
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_読み込み中_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_読み込み中_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_読み込み中_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample一覧画面/testSampleListView_読み込み中_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 

--- a/MVVMArchitectureTemplateSnapshotTests/Reports/Sample編集画面.md
+++ b/MVVMArchitectureTemplateSnapshotTests/Reports/Sample編集画面.md
@@ -4,11 +4,11 @@
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample編集画面/testSampleEditView_編集_有効_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample編集画面/testSampleEditView_編集_有効_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample編集画面/testSampleEditView_編集_有効_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample編集画面/testSampleEditView_編集_有効_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 |編集無効ダークモード|編集無効ライトモード|
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample編集画面/testSampleEditView_編集_無効_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample編集画面/testSampleEditView_編集_無効_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample編集画面/testSampleEditView_編集_無効_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample編集画面/testSampleEditView_編集_無効_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 

--- a/MVVMArchitectureTemplateSnapshotTests/Reports/Sample詳細画面.md
+++ b/MVVMArchitectureTemplateSnapshotTests/Reports/Sample詳細画面.md
@@ -4,23 +4,23 @@
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_内容_長文_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_内容_長文_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_内容_長文_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_内容_長文_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 |タイトル長文ダークモード|タイトル長文ライトモード|
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_長文_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_長文_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_長文_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_長文_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 |内容長文ダークモード|内容長文ライトモード|
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_内容_長文_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_内容_長文_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_内容_長文_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetailView_内容_長文_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 |標準ダークモード|標準ライトモード|
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetail_標準_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetail_標準_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetail_標準_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample詳細画面/testSampleDetail_標準_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 

--- a/MVVMArchitectureTemplateSnapshotTests/Reports/Sample追加画面.md
+++ b/MVVMArchitectureTemplateSnapshotTests/Reports/Sample追加画面.md
@@ -4,11 +4,11 @@
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample追加画面/testSampleAddView_作成_有効_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample追加画面/testSampleAddView_作成_有効_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample追加画面/testSampleAddView_作成_有効_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample追加画面/testSampleAddView_作成_有効_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 |作成無効ダークモード|作成無効ライトモード|
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='../ReferenceImages_64/Sample追加画面/testSampleAddView_作成_無効_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample追加画面/testSampleAddView_作成_無効_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='../ReferenceImages_64/Sample追加画面/testSampleAddView_作成_無効_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='../ReferenceImages_64/Sample追加画面/testSampleAddView_作成_無効_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 |:---:|:---:|
 |16.4|16.4|
 |iPhone14|iPhone14|
-|<img src='MVVMArchitectureTemplateSnapshotTests/ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_長文_ダークモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|<img src='MVVMArchitectureTemplateSnapshotTests/ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_長文_ライトモード_iPhone_16_4_390x844@3x.png' width='390' style='border: 1px solid #999' />|
+|<img src='MVVMArchitectureTemplateSnapshotTests/ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_長文_ダークモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|<img src='MVVMArchitectureTemplateSnapshotTests/ReferenceImages_64/Sample詳細画面/testSampleDetailView_タイトル_長文_ライトモード_iPhone_16_4_390x844@3x.png' width='250' style='border: 1px solid #999' />|
 
 ## Target OS
 
@@ -35,7 +35,7 @@
 
 ## Architecture
 
-**MVVM**
+**MVVM + Swift Concurrency + SwiftUI**
 
 * **Model**(Target UnitTest)
   - **Converter**

--- a/Scripts/Snapshot/screenshots-preview-generator-for-snapshot.rb
+++ b/Scripts/Snapshot/screenshots-preview-generator-for-snapshot.rb
@@ -8,7 +8,7 @@ NUMBER_OF_ROWS = 5
 NUMBER_OF_COLUMNS = 2
 
 # 画像の幅
-IMAGE_WIDTH = 390
+IMAGE_WIDTH = 250
 
 def createMarkdown
     # スキーム名


### PR DESCRIPTION
## やったこと
- スナップショットのレポート出力幅サイズを390から250に変更
- README更新

## PRタイプ
- [ ] 🆕新機能
- [ ] 🐛バグ対応
- [x] 🧹リファクタリング
- [ ] 📖ドキュメント整備
- [ ] 💻開発環境
- [ ] ✅テスト

## issue
- close